### PR TITLE
chore: remove nightly fmt statements

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -4,20 +4,13 @@ max_width = 100
 use_small_heuristics = "Max"
 
 # Imports
-imports_granularity = "Crate"
 reorder_imports = true
 
 # Consistency
 newline_style = "Unix"
 
 # Misc
-binop_separator = "Back"
 chain_width = 80
-match_arm_blocks = false
 match_arm_leading_pipes = "Preserve"
 match_block_trailing_comma = true
-reorder_impl_items = false
-spaces_around_ranges = false
-trailing_comma = "Vertical"
-trailing_semicolon = false
 use_field_init_shorthand = true


### PR DESCRIPTION
These statements are not allowed in the `stable` version of Rust and should hence be removed.