### PR TITLE
Fix: pay fees with native parachain token (EPT companion #83)

### DIFF
--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -218,8 +218,7 @@ impl xcm_executor::Config for XcmConfig {
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
-	type Trader =
-		UsingComponents<WeightToFee, RelayLocation, AccountId, Balances, ToAuthor<Runtime>>;
+	type Trader = UsingComponents<WeightToFee, SelfReserve, AccountId, Balances, ToAuthor<Runtime>>;
 	type ResponseHandler = PolkadotXcm;
 	type AssetTrap = PolkadotXcm;
 	type AssetClaims = PolkadotXcm;


### PR DESCRIPTION
Use `SelfReserve` for fee payment on receiving XCM. See https://github.com/paritytech/extended-parachain-template/pull/83